### PR TITLE
Run Kontena commands forked

### DIFF
--- a/lib/kontena/plugin/shell/commands/kontena.rb
+++ b/lib/kontena/plugin/shell/commands/kontena.rb
@@ -77,6 +77,7 @@ module Kontena::Plugin
 
         write.close
         output = read.read
+        print "\e[0m" # Reset terminal
         Process.wait(pid)
         Kontena.logger.debug { "Process #{pid} finished, #{output.size} bytes in result" }
 

--- a/lib/kontena/plugin/shell/commands/kontena.rb
+++ b/lib/kontena/plugin/shell/commands/kontena.rb
@@ -24,10 +24,14 @@ module Kontena::Plugin
         if cmd.subcommand_name && cmd.subcommand_name == 'shell'
           puts Kontena.pastel.red("Already running inside KOSH")
         else
-          cmd.run([])
+          if forked_run == :context
+            context.concat(args)
+          end
         end
       rescue Clamp::HelpWanted => ex
-        unless args.include?('--help') || args.include?('-h')
+        if args.include?('--help') || args.include?('-h')
+          puts subcommand_class.help('')
+        else
           context.concat(args)
         end
       rescue SystemExit => ex
@@ -37,7 +41,7 @@ module Kontena::Plugin
       end
 
       def subcommand_class
-        (context + args).reject { |t| t.start_with?('-') }.inject(Kontena::MainCommand) do |base, token|
+        result = (context + args).reject { |t| t.start_with?('-') }.inject(Kontena::MainCommand) do |base, token|
           if base.has_subcommands?
             sc = base.recognised_subcommands.find { |sc| sc.names.include?(token) }
             sc ? sc.subcommand_class : base
@@ -45,6 +49,40 @@ module Kontena::Plugin
             base
           end
         end
+        result
+      end
+
+      def forked_run
+        read, write = IO.pipe
+        pid = fork do
+          read.close
+          result = nil
+          exception = nil
+          begin
+            result = cmd.run([])
+          rescue Clamp::HelpWanted => ex
+            if args.include?('--help') || args.include?('-h')
+              puts cmd.class.help('').gsub(/^(\s+)\[OPTIONS\] SUB/, "\\1 SUB")
+            else
+              result = :context
+              exception = nil
+            end
+          rescue SystemExit, StandardError => ex
+            exception = ex
+          end
+          Marshal.dump({ result: result, exception: exception }, write)
+          exit(0)
+        end
+        Kontena.logger.debug { "Forked subcommand, pid: #{pid}" }
+
+        write.close
+        output = read.read
+        Process.wait(pid)
+        Kontena.logger.debug { "Process #{pid} finished, #{output.size} bytes in result" }
+
+        data = Marshal.load(output)
+        raise data[:exception] if data[:exception]
+        data[:result]
       end
     end
   end

--- a/spec/kontena/plugin/shell/commands/kontena_spec.rb
+++ b/spec/kontena/plugin/shell/commands/kontena_spec.rb
@@ -1,7 +1,7 @@
 describe Kontena::Plugin::Shell::KontenaCommand do
   context '#run' do
     it 'should be able to run kontena commands' do
-      expect{described_class.new([], ['version', '--cli']).run}.to output(/cli:/).to_stdout
+      expect{described_class.new([], ['version', '--cli']).run}.to output(/cli:/).to_stdout_from_any_process
     end
 
     it 'should not run a shell inside a shell' do


### PR DESCRIPTION
Aims to fix #31

This PR makes the kontena commands run in a forked process to kill any left behind threads and revert changes made to globals.

The major downside is that it does not work on windows, jruby, rbx or other non-forking platforms, making this PR pretty much pointless.

