### PR TITLE
Clear the spinner-threads array after executing commands

### DIFF
--- a/lib/kontena/plugin/shell/commands/kontena.rb
+++ b/lib/kontena/plugin/shell/commands/kontena.rb
@@ -27,13 +27,17 @@ module Kontena::Plugin
           cmd.run([])
         end
       rescue Clamp::HelpWanted => ex
-        unless args.include?('--help') || args.include?('-h')
+        if args.include?('--help') || args.include?('-h')
+          puts cmd.class.help('')
+        else
           context.concat(args)
         end
       rescue SystemExit => ex
         puts Kontena.pastel.red('[Command exited with error]') unless ex.status.zero?
       rescue => ex
         puts Kontena.pastel.red("ERROR: #{ex.message}")
+      ensure
+        Thread.main['spinners'] && Thread.main['spinners'].map(&:kill) && Thread.main['spinners'] = nil
       end
 
       def subcommand_class

--- a/lib/kontena/plugin/shell/commands/kontena.rb
+++ b/lib/kontena/plugin/shell/commands/kontena.rb
@@ -27,9 +27,7 @@ module Kontena::Plugin
           cmd.run([])
         end
       rescue Clamp::HelpWanted => ex
-        if args.include?('--help') || args.include?('-h')
-          puts cmd.class.help('')
-        else
+        unless args.include?('--help') || args.include?('-h')
           context.concat(args)
         end
       rescue SystemExit => ex


### PR DESCRIPTION
Replaces #32
Fixes #31 

When `Kontena.run!(....)` crashes during a spinner, it may leave behind threads that make `Kontena::Cli::Common` to [hijack](https://github.com/kontena/kontena/blob/master/cli/lib/kontena/cli/common.rb#L91) `puts`. This PR clears the spinners array after each run.
