### PR TITLE
Fix commands like "stack --help" to print help

### DIFF
--- a/lib/kontena/plugin/shell/commands/kontena.rb
+++ b/lib/kontena/plugin/shell/commands/kontena.rb
@@ -27,7 +27,9 @@ module Kontena::Plugin
           cmd.run([])
         end
       rescue Clamp::HelpWanted => ex
-        unless args.include?('--help') || args.include?('-h')
+        if args.include?('--help') || args.include?('-h')
+          puts cmd.class.help('')
+        else
           context.concat(args)
         end
       rescue SystemExit => ex


### PR DESCRIPTION
Before this PR something like `stack --help` does nothing. After this PR it prints the help as expected.
