### PR TITLE
Release 0.1.3

### DIFF
--- a/bin/kosh
+++ b/bin/kosh
@@ -16,7 +16,7 @@ end
 
 ARGV.unshift('shell')
 
-Kontena::PluginManager.instance.init
+Kontena::PluginManager.respond_to?(:instance) ? Kontena::PluginManager.instance.init : Kontena::PluginManager.init
 Kontena::MainCommand.run
 __END__
 Usage: kosh [options] [initial_context]

--- a/build/edge.sh
+++ b/build/edge.sh
@@ -6,6 +6,7 @@ if [ ! -z "$DOCKER_USERNAME" ] && [ ! -z "$DOCKER_PASSWORD" ]; then
     docker build -t kontena/kosh:edge .
     docker build --build-arg CLI_VERSION=1.2.0 -t kontena/kosh:edge-cli-1.2 .
     docker build --build-arg CLI_VERSION=1.3.0 -t kontena/kosh:edge-cli-1.3 .
+    docker build --build-arg CLI_VERSION=1.4.0.rc1 -t kontena/kosh:edge-cli-1.4rc1 .
 
     docker push kontena/kosh:edge
     docker push kontena/kosh:edge-cli-1.2

--- a/build/edge.sh
+++ b/build/edge.sh
@@ -11,4 +11,5 @@ if [ ! -z "$DOCKER_USERNAME" ] && [ ! -z "$DOCKER_PASSWORD" ]; then
     docker push kontena/kosh:edge
     docker push kontena/kosh:edge-cli-1.2
     docker push kontena/kosh:edge-cli-1.3
+    docker push kontena/kosh:edge-cli-1.4rc1
 fi

--- a/lib/kontena/plugin/shell/version.rb
+++ b/lib/kontena/plugin/shell/version.rb
@@ -1,7 +1,7 @@
 module Kontena
   module Plugin
     module Shell
-      VERSION = '0.1.2'
+      VERSION = '0.1.3'
     end
   end
 end


### PR DESCRIPTION
- Update dockerfile (alpine 3.6, ruby 2.4, dont run as root) (#35)
- Speed up cli startup by lazy loading kosh when installed (#22)
- Make `some_command --help` to print help (#34)
- Fix blank output by destroying left around threads after commands run (#33)  …
- Improve CLI  1.4 compatibility and build edge-1.4.0rc1
